### PR TITLE
Fix session ambr nas encoding

### DIFF
--- a/nasConvert/SessionAMBR.go
+++ b/nasConvert/SessionAMBR.go
@@ -19,13 +19,13 @@ func ModelsToSessionAMBR(ambr *models.Ambr) (sessAmbr nasType.SessionAMBR) {
 
 	uplink := strings.Split(ambr.Uplink, " ")
 	bitRate, _ = strconv.ParseInt(uplink[0], 10, 16)
-	binary.LittleEndian.PutUint16(bitRateBytes[:], uint16(bitRate))
+	binary.BigEndian.PutUint16(bitRateBytes[:], uint16(bitRate))
 	sessAmbr.SetSessionAMBRForUplink(bitRateBytes)
 	sessAmbr.SetUnitForSessionAMBRForUplink(strToAMBRUnit(uplink[1]))
 
 	downlink := strings.Split(ambr.Downlink, " ")
 	bitRate, _ = strconv.ParseInt(downlink[0], 10, 16)
-	binary.LittleEndian.PutUint16(bitRateBytes[:], uint16(bitRate))
+	binary.BigEndian.PutUint16(bitRateBytes[:], uint16(bitRate))
 	sessAmbr.SetSessionAMBRForDownlink(bitRateBytes)
 	sessAmbr.SetUnitForSessionAMBRForDownlink(strToAMBRUnit(downlink[1]))
 	return


### PR DESCRIPTION
Hi team,

This fixes the AMBR encoding is nasConvert library, they are used in the `PDU session establishment accept`, which could affect the RAN side.

Attached images can also be reproduced by TestRegistration.

Best,
Chi

AMBR encoding (before)
![Screen Shot 2020-08-13 at 22 52 08](https://user-images.githubusercontent.com/8851038/90150167-f822b800-ddb7-11ea-9140-4b5351914a69.png)

Before & after
![Screen Shot 2020-08-13 at 22 52 13](https://user-images.githubusercontent.com/8851038/90150200-feb12f80-ddb7-11ea-8958-c5b9826e97e1.png)


