### PR TITLE
Add missing constants for PDU session establishment messages

### DIFF
--- a/nasConvert/ProtocolConfigurationOptions.go
+++ b/nasConvert/ProtocolConfigurationOptions.go
@@ -12,7 +12,7 @@ import (
 
 type ProtocolOrContainerUnit struct {
 	ProtocolOrContainerID uint16
-	LengthofContents      uint8
+	LengthOfContents      uint8
 	Contents              []byte
 }
 
@@ -31,7 +31,7 @@ const (
 func NewProtocolOrContainerUnit() (pcu *ProtocolOrContainerUnit) {
 	pcu = &ProtocolOrContainerUnit{
 		ProtocolOrContainerID: 0,
-		LengthofContents:      0,
+		LengthOfContents:      0,
 		Contents:              []byte{},
 	}
 	return
@@ -60,7 +60,7 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) Marshal() (nas
 	for _, containerUnit := range protocolConfigurationOptions.ProtocolOrContainerList {
 
 		binary.Write(buffer, binary.BigEndian, &containerUnit.ProtocolOrContainerID)
-		binary.Write(buffer, binary.BigEndian, &containerUnit.LengthofContents)
+		binary.Write(buffer, binary.BigEndian, &containerUnit.LengthOfContents)
 		binary.Write(buffer, binary.BigEndian, &containerUnit.Contents)
 	}
 
@@ -96,20 +96,20 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) UnMarshal(data
 			readingState = ReadingLength
 			numOfBytes = numOfBytes - 2
 		case ReadingLength:
-			err = binary.Read(byteReader, binary.BigEndian, &curContainer.LengthofContents)
+			err = binary.Read(byteReader, binary.BigEndian, &curContainer.LengthOfContents)
 			if err != nil {
 				return err
 			}
-			logger.ConvertLog.Traceln("Reading Length: ", strconv.Itoa(int(curContainer.LengthofContents)))
+			logger.ConvertLog.Traceln("Reading Length: ", strconv.Itoa(int(curContainer.LengthOfContents)))
 			readingState = ReadingContent
 			numOfBytes = numOfBytes - 1
-			if curContainer.LengthofContents == 0 {
+			if curContainer.LengthOfContents == 0 {
 				protocolConfigurationOptions.ProtocolOrContainerList = append(protocolConfigurationOptions.ProtocolOrContainerList, curContainer)
 				logger.ConvertLog.Traceln("For loop ProtocolOrContainerList: ", protocolConfigurationOptions.ProtocolOrContainerList)
 			}
 		case ReadingContent:
-			if curContainer.LengthofContents > 0 {
-				curContainer.Contents = make([]uint8, curContainer.LengthofContents)
+			if curContainer.LengthOfContents > 0 {
+				curContainer.Contents = make([]uint8, curContainer.LengthOfContents)
 				err = binary.Read(byteReader, binary.BigEndian, curContainer.Contents)
 				if err != nil {
 					return err
@@ -117,7 +117,7 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) UnMarshal(data
 				protocolConfigurationOptions.ProtocolOrContainerList = append(protocolConfigurationOptions.ProtocolOrContainerList, curContainer)
 				logger.ConvertLog.Traceln("For loop ProtocolOrContainerList: ", protocolConfigurationOptions.ProtocolOrContainerList)
 			}
-			numOfBytes = numOfBytes - int(curContainer.LengthofContents)
+			numOfBytes = numOfBytes - int(curContainer.LengthOfContents)
 			readingState = ReadingID
 		}
 	}
@@ -130,7 +130,7 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddDNSServerIP
 	protocolOrContainerUnit := NewProtocolOrContainerUnit()
 
 	protocolOrContainerUnit.ProtocolOrContainerID = nasMessage.DNSServerIPv4AddressRequestUL
-	protocolOrContainerUnit.LengthofContents = 0
+	protocolOrContainerUnit.LengthOfContents = 0
 
 	protocolConfigurationOptions.ProtocolOrContainerList = append(protocolConfigurationOptions.ProtocolOrContainerList, protocolOrContainerUnit)
 }
@@ -139,7 +139,7 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddDNSServerIP
 	protocolOrContainerUnit := NewProtocolOrContainerUnit()
 
 	protocolOrContainerUnit.ProtocolOrContainerID = nasMessage.DNSServerIPv6AddressRequestUL
-	protocolOrContainerUnit.LengthofContents = 0
+	protocolOrContainerUnit.LengthOfContents = 0
 
 	protocolConfigurationOptions.ProtocolOrContainerList = append(protocolConfigurationOptions.ProtocolOrContainerList, protocolOrContainerUnit)
 }
@@ -148,7 +148,7 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddIPAddressAl
 	protocolOrContainerUnit := NewProtocolOrContainerUnit()
 
 	protocolOrContainerUnit.ProtocolOrContainerID = nasMessage.IPAddressAllocationViaNASSignallingUL
-	protocolOrContainerUnit.LengthofContents = 0
+	protocolOrContainerUnit.LengthOfContents = 0
 
 	protocolConfigurationOptions.ProtocolOrContainerList = append(protocolConfigurationOptions.ProtocolOrContainerList, protocolOrContainerUnit)
 }
@@ -170,8 +170,8 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddDNSServerIP
 	protocolOrContainerUnit := NewProtocolOrContainerUnit()
 
 	protocolOrContainerUnit.ProtocolOrContainerID = nasMessage.DNSServerIPv4AddressDL
-	protocolOrContainerUnit.LengthofContents = uint8(net.IPv4len)
-	logger.ConvertLog.Traceln("LengthofContents: ", protocolOrContainerUnit.LengthofContents)
+	protocolOrContainerUnit.LengthOfContents = uint8(net.IPv4len)
+	logger.ConvertLog.Traceln("LengthOfContents: ", protocolOrContainerUnit.LengthOfContents)
 	protocolOrContainerUnit.Contents = append(protocolOrContainerUnit.Contents, dnsIP.To4()...)
 	logger.ConvertLog.Traceln("Contents: ", protocolOrContainerUnit.Contents)
 
@@ -194,8 +194,22 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddDNSServerIP
 	protocolOrContainerUnit := NewProtocolOrContainerUnit()
 
 	protocolOrContainerUnit.ProtocolOrContainerID = nasMessage.DNSServerIPv6AddressDL
-	protocolOrContainerUnit.LengthofContents = uint8(net.IPv6len)
+	protocolOrContainerUnit.LengthOfContents = uint8(net.IPv6len)
 	protocolOrContainerUnit.Contents = append(protocolOrContainerUnit.Contents, dnsIP.To16()...)
+
+	protocolConfigurationOptions.ProtocolOrContainerList = append(protocolConfigurationOptions.ProtocolOrContainerList, protocolOrContainerUnit)
+	return
+}
+
+func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddIPv4LinkMTU(mtu uint16) (err error) {
+	logger.ConvertLog.Traceln("In AddIPv4LinkMTU")
+	protocolOrContainerUnit := NewProtocolOrContainerUnit()
+
+	protocolOrContainerUnit.ProtocolOrContainerID = nasMessage.IPv4LinkMTUDL
+	protocolOrContainerUnit.LengthOfContents = 2
+	logger.ConvertLog.Traceln("LengthOfContents: ", protocolOrContainerUnit.LengthOfContents)
+	protocolOrContainerUnit.Contents = append(protocolOrContainerUnit.Contents, []byte{uint8(mtu >> 8), uint8(mtu & 0xff)}...)
+	logger.ConvertLog.Traceln("Contents: ", protocolOrContainerUnit.Contents)
 
 	protocolConfigurationOptions.ProtocolOrContainerList = append(protocolConfigurationOptions.ProtocolOrContainerList, protocolOrContainerUnit)
 	return

--- a/nasMessage/NAS_CommInfoIE.go
+++ b/nasMessage/NAS_CommInfoIE.go
@@ -268,31 +268,40 @@ const (
 
 //TS 24.008 10.5.6.3
 const (
-	PCSCFIPv6AddressRequestUL                                  uint16 = 0x0001
-	IMCNSubsystemSignalingFlagUL                               uint16 = 0x0002
-	DNSServerIPv6AddressRequestUL                              uint16 = 0x0003
-	NotSupportedUL                                             uint16 = 0x0004
-	MSSupportOfNetworkRequestedBearerControlIndicatorUL        uint16 = 0x0005
-	DSMIPv6HomeAgentAddressRequestUL                           uint16 = 0x0007
-	DSMIPv6HomeNetworkPrefixRequestUL                          uint16 = 0x0008
-	DSMIPv6IPv4HomeAgentAddressRequestUL                       uint16 = 0x0009
-	IPAddressAllocationViaNASSignallingUL                      uint16 = 0x000a
-	IPv4AddressAllocationViaDHCPv4UL                           uint16 = 0x000b
-	PCSCFIPv4AddressRequestUL                                  uint16 = 0x000c
-	DNSServerIPv4AddressRequestUL                              uint16 = 0x000d
-	MSISDNRequestUL                                            uint16 = 0x000e
-	IFOMSupportRequestUL                                       uint16 = 0x000f
-	IPv4LinkMTURequestUL                                       uint16 = 0x0010
-	MSSupportOfLocalAddressInTFTIndicatorUL                    uint16 = 0x0011
-	PCSCFReSelectionSupportUL                                  uint16 = 0x0012
-	NBIFOMRequestIndicatorUL                                   uint16 = 0x0013
-	NBIFOMModeUL                                               uint16 = 0x0014
-	NonIPLinkMTURequestUL                                      uint16 = 0x0015
-	APNRateControlSupportIndicatorUL                           uint16 = 0x0016
-	UEStatus3GPPPSDataOffUL                                    uint16 = 0x0017
-	ReliableDataServiceRequestIndicatorUL                      uint16 = 0x0018
-	AdditionalAPNRateControlForExceptionDataSupportIndicatorUL uint16 = 0x0019
-	PDUSessionIDUL                                             uint16 = 0x001a
+	PCSCFIPv6AddressRequestUL                                     uint16 = 0x0001
+	IMCNSubsystemSignalingFlagUL                                  uint16 = 0x0002
+	DNSServerIPv6AddressRequestUL                                 uint16 = 0x0003
+	NotSupportedUL                                                uint16 = 0x0004
+	MSSupportOfNetworkRequestedBearerControlIndicatorUL           uint16 = 0x0005
+	DSMIPv6HomeAgentAddressRequestUL                              uint16 = 0x0007
+	DSMIPv6HomeNetworkPrefixRequestUL                             uint16 = 0x0008
+	DSMIPv6IPv4HomeAgentAddressRequestUL                          uint16 = 0x0009
+	IPAddressAllocationViaNASSignallingUL                         uint16 = 0x000a
+	IPv4AddressAllocationViaDHCPv4UL                              uint16 = 0x000b
+	PCSCFIPv4AddressRequestUL                                     uint16 = 0x000c
+	DNSServerIPv4AddressRequestUL                                 uint16 = 0x000d
+	MSISDNRequestUL                                               uint16 = 0x000e
+	IFOMSupportRequestUL                                          uint16 = 0x000f
+	IPv4LinkMTURequestUL                                          uint16 = 0x0010
+	MSSupportOfLocalAddressInTFTIndicatorUL                       uint16 = 0x0011
+	PCSCFReSelectionSupportUL                                     uint16 = 0x0012
+	NBIFOMRequestIndicatorUL                                      uint16 = 0x0013
+	NBIFOMModeUL                                                  uint16 = 0x0014
+	NonIPLinkMTURequestUL                                         uint16 = 0x0015
+	APNRateControlSupportIndicatorUL                              uint16 = 0x0016
+	UEStatus3GPPPSDataOffUL                                       uint16 = 0x0017
+	ReliableDataServiceRequestIndicatorUL                         uint16 = 0x0018
+	AdditionalAPNRateControlForExceptionDataSupportIndicatorUL    uint16 = 0x0019
+	PDUSessionIDUL                                                uint16 = 0x001a
+	EthernetFramePayloadMTURequestUL                              uint16 = 0x0020
+	UnstructuredLinkMTURequestUL                                  uint16 = 0x0021
+	I5GSMCauseValueUL                                             uint16 = 0x0022 // 5GSMCauseValueUL
+	QoSRulesWithTheLengthOfTwoOctetsSupportIndicatorUL            uint16 = 0x0023
+	QoSFlowDescriptionsWithTheLengthOfTwoOctetsSupportIndicatorUL uint16 = 0x0024
+	LinkControlProtocolUL                                         uint16 = 0xc021
+	PushAccessControlProtocolUL                                   uint16 = 0xc023
+	ChallengeHandshakeAuthenticationProtocolUL                    uint16 = 0xc223
+	InternetProtocolControlProtocolUL                             uint16 = 0x8021
 )
 
 //TS 24.008 10.5.6.3
@@ -323,4 +332,9 @@ const (
 	QoSRulesDL                                           uint16 = 0x001c
 	SessionAMBRDL                                        uint16 = 0x001d
 	PDUSessionAddressLifetimeDL                          uint16 = 0x001e
+	QoSFlowDescriptions                                  uint16 = 0x001f
+	EthernetFramePayloadMTU                              uint16 = 0x0020
+	UnstructuredLinkMTU                                  uint16 = 0x0021
+	QoSRulesWithTheLengthOfTwoOctets                     uint16 = 0x0023
+	QoSFlowDescriptionsWithTheLengthOfTwoOctets          uint16 = 0x0024
 )


### PR DESCRIPTION
This PR added constants in TS 24.008 10.5.6.3 in order to support more IEs in PDU session establishment messages, thanks.
