### PR TITLE
The length of nas qos rule is 2 octets

### DIFF
--- a/nasType/NAS_RequestedQosRules.go
+++ b/nasType/NAS_RequestedQosRules.go
@@ -4,7 +4,7 @@ package nasType
 // QoSRules Row, sBit, len = [0, 0], 8 , INF
 type RequestedQosRules struct {
 	Iei    uint8
-	Len    uint8
+	Len    uint16
 	Buffer []uint8
 }
 
@@ -28,13 +28,13 @@ func (a *RequestedQosRules) SetIei(iei uint8) {
 
 // RequestedQosRules 9.11.4.13
 // Len Row, sBit, len = [], 8, 8
-func (a *RequestedQosRules) GetLen() (len uint8) {
+func (a *RequestedQosRules) GetLen() (len uint16) {
 	return a.Len
 }
 
 // RequestedQosRules 9.11.4.13
 // Len Row, sBit, len = [], 8, 8
-func (a *RequestedQosRules) SetLen(len uint8) {
+func (a *RequestedQosRules) SetLen(len uint16) {
 	a.Len = len
 	a.Buffer = make([]uint8, a.Len)
 }

--- a/nasType/NAS_RequestedQosRules.go
+++ b/nasType/NAS_RequestedQosRules.go
@@ -27,13 +27,13 @@ func (a *RequestedQosRules) SetIei(iei uint8) {
 }
 
 // RequestedQosRules 9.11.4.13
-// Len Row, sBit, len = [], 8, 8
+// Len Row, sBit, len = [], 16, 16
 func (a *RequestedQosRules) GetLen() (len uint16) {
 	return a.Len
 }
 
 // RequestedQosRules 9.11.4.13
-// Len Row, sBit, len = [], 8, 8
+// Len Row, sBit, len = [], 16, 16
 func (a *RequestedQosRules) SetLen(len uint16) {
 	a.Len = len
 	a.Buffer = make([]uint8, a.Len)


### PR DESCRIPTION
As described in ts 24.501 clause 9.11.4.13

```

8 | 7 | 6 | 5 | 4 | 3 | 2 | 1 |  
-------------------------------
       QoS rules IEI              octet 1
-------------------------------
                                           octet 2
 Length of QoS rules IE      octet 3
-------------------------------
```






