### PR TITLE
5G GUTI octet 4 (four 1bits) encoding/decoding fix.

### DIFF
--- a/nasConvert/MobileIdentity5GS.go
+++ b/nasConvert/MobileIdentity5GS.go
@@ -112,6 +112,7 @@ func GutiToNas(guti string) nasType.GUTI5G {
 
 	gutiNas.SetLen(11)
 	gutiNas.SetSpare(0)
+	gutiNas.SetSpare2(15)
 	gutiNas.SetTypeOfIdentity(nasMessage.MobileIdentity5GSType5gGuti)
 
 	var mcc1, mcc2, mcc3, mnc1, mnc2, mnc3 int

--- a/nasType/NAS_GUTI5G.go
+++ b/nasType/NAS_GUTI5G.go
@@ -1,6 +1,7 @@
 package nasType
 
 // GUTI5G 9.11.3.4
+// Spare2 Row, sBit, len = [0, 0], 8 , 4
 // Spare Row, sBit, len = [0, 0], 4 , 1
 // TypeOfIdentity Row, sBit, len = [0, 0], 3 , 3
 // MCCDigit2 Row, sBit, len = [1, 1], 8 , 4
@@ -47,6 +48,18 @@ func (a *GUTI5G) GetLen() (len uint16) {
 // Len Row, sBit, len = [], 8, 16
 func (a *GUTI5G) SetLen(len uint16) {
 	a.Len = len
+}
+
+// GUTI5G 9.11.3.4
+// Spare2 Row, sBit, len = [0, 0], 8 , 4
+func (a *GUTI5G) GetSpare2() (spare uint8) {
+	return a.Octet[0] & GetBitMask(8, 4) >> (4)
+}
+
+// GUTI5G 9.11.3.4
+// Spare2 Row, sBit, len = [0, 0], 8 , 4
+func (a *GUTI5G) SetSpare2(spare uint8) {
+	a.Octet[0] = (a.Octet[0] & 15) + ((spare & 15) << 4)
 }
 
 // GUTI5G 9.11.3.4


### PR DESCRIPTION
In TS 24.501 9.11.3.4. "5G-GUTI" has four 1bit in octet 4.
It is not properly encoded/decoded.  This PR fix the issue.
