### PR TITLE
NAS LastVisitedRegisteredTAI length fix

### DIFF
--- a/nasType/NAS_LastVisitedRegisteredTAI.go
+++ b/nasType/NAS_LastVisitedRegisteredTAI.go
@@ -10,7 +10,7 @@ package nasType
 // TAC Row, sBit, len = [3, 5], 8 , 24
 type LastVisitedRegisteredTAI struct {
 	Iei   uint8
-	Octet [7]uint8
+	Octet [6]uint8
 }
 
 func NewLastVisitedRegisteredTAI(iei uint8) (lastVisitedRegisteredTAI *LastVisitedRegisteredTAI) {


### PR DESCRIPTION
NAS LastVisitedRegisterdTAI length fix(8byte→7byte). 

Spec TS 24.501 says

Table 8.2.6.1.1: REGISTRATION REQUEST message content
**Last visited registered TAI Length = 7**
