### PR TITLE
Added AddPCscfIPv4Address for IMS support

### DIFF
--- a/nasConvert/ProtocolConfigurationOptions.go
+++ b/nasConvert/ProtocolConfigurationOptions.go
@@ -190,6 +190,27 @@ func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddDNSServerIP
 	return
 }
 
+func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddPCscfIPv4Address(pcscfIP net.IP) (err error) {
+	if pcscfIP.To4() == nil {
+		err = fmt.Errorf("The P-CSCF IP should be IPv4!")
+		return
+	}
+	pcscfIP = pcscfIP.To4()
+
+	if len(pcscfIP) != net.IPv4len {
+		err = fmt.Errorf("The length of P-CSCF IP IPv4 is wrong!")
+		return
+	}
+
+	protocolOrContainerUnit := NewProtocolOrContainerUnit()
+	protocolOrContainerUnit.ProtocolOrContainerID = nasMessage.PCSCFIPv4AddressDL
+	protocolOrContainerUnit.LengthOfContents = uint8(net.IPv4len)
+	protocolOrContainerUnit.Contents = append(protocolOrContainerUnit.Contents, pcscfIP.To4()...)
+
+	protocolConfigurationOptions.ProtocolOrContainerList = append(protocolConfigurationOptions.ProtocolOrContainerList, protocolOrContainerUnit)
+	return
+}
+
 func (protocolConfigurationOptions *ProtocolConfigurationOptions) AddDNSServerIPv6Address(dnsIP net.IP) (err error) {
 
 	if dnsIP.To16() == nil {


### PR DESCRIPTION
UE does not connect if IMS DNN is not supported as VoLTE seems to be mandantory in 5G SA.

the P-CSCF field indicates the IP address of the IMS server to which the UE should connect to.

Tested with Huawei P40 5G