### PR TITLE
fix NIA0 NEA1

### DIFF
--- a/security/security.go
+++ b/security/security.go
@@ -69,7 +69,7 @@ func NASMacCalculate(AlgoID uint8, KnasInt [16]uint8, Count uint32,
 	switch AlgoID {
 	case AlgIntegrity128NIA0:
 		logger.SecurityLog.Warningln("Integrity NIA0 is emergency.")
-		return nil, nil
+		return make([]byte, 4), nil
 	case AlgIntegrity128NIA1:
 		logger.SecurityLog.Debugf("Use NIA1")
 		return NIA1(KnasInt, Count, Bearer, uint32(Direction), msg, uint64(len(msg))*8)
@@ -97,7 +97,9 @@ func NEA1(ck [16]byte, countC, bearer, direction uint32, ibs []byte, length uint
 	ks := make([]uint32, l)
 	snow3g.GenerateKeystream(int(l), ks)
 	// Clear keystream bits which exceed length
-	ks[l-1] &= ^((1 << (32 - r)) - 1)
+	if r != 0 {
+		ks[l-1] &= ^((1 << (32 - r)) - 1)
+	}
 
 	obs = make([]byte, len(ibs))
 	var i uint32


### PR DESCRIPTION
This PR fix two problem in NIA0 and NEA1 algorithm

First problem is when using NIA0 MAC field in NASpdu is missing, so it will cause decode error in receiver.
And it should be set all 0 in that field when use NIA0 which described in 33.501 D1.

Second problem is the last 32 bits will not be decrypted by NEA1 when input bit stream length is divisible by 32.
This is a bug when clearing keystream bits which exceed length, if length is divisible by 32, last 32 bits of keystream will bitwise and with 0 and cause last 32 bits of cipher not be decrypted.