### PR TITLE
fix(nas):fix out of range about Capability5GMM when Len is oversized

### DIFF
--- a/nasMessage/NAS_RegistrationRequest.go
+++ b/nasMessage/NAS_RegistrationRequest.go
@@ -192,7 +192,11 @@ func (a *RegistrationRequest) DecodeRegistrationRequest(byteArray *[]byte) {
 		case RegistrationRequestCapability5GMMType:
 			a.Capability5GMM = nasType.NewCapability5GMM(ieiN)
 			binary.Read(buffer, binary.BigEndian, &a.Capability5GMM.Len)
-			a.Capability5GMM.SetLen(a.Capability5GMM.GetLen())
+			if int(a.Capability5GMM.GetLen()) > len(a.Capability5GMM.Octet) {
+				a.Capability5GMM.SetLen(13)
+			} else {
+				a.Capability5GMM.SetLen(a.Capability5GMM.GetLen())
+			}
 			binary.Read(buffer, binary.BigEndian, a.Capability5GMM.Octet[:a.Capability5GMM.GetLen()])
 		case RegistrationRequestUESecurityCapabilityType:
 			a.UESecurityCapability = nasType.NewUESecurityCapability(ieiN)


### PR DESCRIPTION
When Capability5GMM's TLV Len is over 13 will lead to free5gc panic(out of range).
Check if Capability5GMM's TLV Len exceed length of content, then set Len to 13(max Len in spec TS 24.501 9.11.3.1).