### PR TITLE
feat: add support for SUCI in NAI format

### DIFF
--- a/nasConvert/MobileIdentity5GS.go
+++ b/nasConvert/MobileIdentity5GS.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -19,10 +20,17 @@ func GetTypeOfIdentity(buf byte) uint8 {
 	return buf & 0x07
 }
 
-// TS 24.501 9.11.3.4
-// suci(imsi) =
-// "suci-0-${mcc}-${mnc}-${routingIndentifier}-${protectionScheme}-${homeNetworkPublicKeyIdentifier}-${schemeOutput}"
-// suci(nai) = "nai-${naiString}"
+/* TS 24.501 Section 9.11.3.4 defines different formats for SUPI: IMSI, NSI (NAI), GCI, GLI.
+ * TS 24.501 Section 9.11.3.4 specifies the encoding of IMSI.
+ * TS 23.003 Section 28.7.3 specifies the encoding of NSI.
+ * TS 23.003 Section 28.15.5 specifies the encoding of GCI.
+ * TS 23.003 Section 28.16.5 specifies the encoding of GLI.
+ * The following functions SuciToString and SuciToStringWithError return the SUCI in string format
+ * as sent on the UDM API via the SupiOrSuci data type, as described in Annex C of TS 29.503.
+ * Example format:
+ * suci-${supiType}-${homeNetworkId}-${routingIndicator}-${protectionSchemeId}-${homeNetworkPublicKeyID}-${schemeOutput}
+ */
+
 func SuciToString(buf []byte) (suci string, plmnId string) {
 	var err error
 	suci, plmnId, err = SuciToStringWithError(buf)
@@ -42,8 +50,12 @@ func SuciToStringWithError(buf []byte) (suci string, plmnId string, err error) {
 
 	supiFormat := (buf[0] & 0xf0) >> 4
 	if supiFormat == nasMessage.SupiFormatNai {
-		suci, err = naiToString(buf)
-		return suci, "", err
+		suci, plmnId, err = naiToString(buf[1:])
+		return suci, plmnId, err
+	} else if supiFormat == nasMessage.SupiFormatGCI {
+		return "", "", errors.New("GCI not supported")
+	} else if supiFormat == nasMessage.SupiFormatGLI {
+		return "", "", errors.New("GLI not supported")
 	}
 
 	if len(buf) < 9 {
@@ -106,9 +118,28 @@ func SuciToStringWithError(buf []byte) (suci string, plmnId string, err error) {
 	return suci, plmnId, nil
 }
 
+/* NAI format for SUCI has the form username@realm (Ref. TS 24 501 Sec. 28.7). Where:
+ * realm = [ (nai.)5gc.mnc<MNC>.mcc<MCC>.3gppnetwork.org || <NSI realm> ]
+ * username = type<supi type>.rid<routing indicator>.schid<protection scheme id>
+ * [ .userid<MSIN || NSI username> ||
+ * .hnkey<home network public key id>.ecckey<ECC ephemeral public key>.cip<ciphertext>.mac<MAC tag> ||
+ * .hnkey<home network public key id>.out<HPLMN defined scheme output>
+ * ]
+ * The following NaiToString function takes as input a SUCI in NAI format and returns its encoding for the UDM APIs.
+ * The final SUCI string has the form:
+ * "suci-<supi type>-[<MCC>-<MNC> || <NSI realm>]-<routing indicator>-<protection scheme id>-
+ * [<home network public key id> || 0]-[<MSIN> || <NSI username> ||
+ * <ECC ephemeral public key><ciphertext><MAC tag> || <HPLMN defined scheme output>]"
+ */
+
+var reBase = regexp.MustCompile(`^type(\d{1})\.rid(\d{1,4})\.schid(\d{1})`)
+var reHN = regexp.MustCompile(`^\.hnkey(\d{1,3})`)
+var reECC = regexp.MustCompile(`^\.ecckey([^.]+)\.cip([^.]+)\.mac([^.]+)`)
+var rePLMN = regexp.MustCompile(`^.*\.mnc(\d{2,3})\.mcc(\d{3})\.3gppnetwork\.org$`)
+
 func NaiToString(buf []byte) (nai string) {
 	var err error
-	nai, err = naiToString(buf)
+	nai, _, err = naiToString(buf)
 	if err != nil {
 		logger.ConvertLog.Warnf("NaiToString: %+v", err)
 		return ""
@@ -116,15 +147,92 @@ func NaiToString(buf []byte) (nai string) {
 	return
 }
 
-func naiToString(buf []byte) (nai string, err error) {
-	if len(buf) < 2 {
-		return "", errors.New("too short NAI")
+func naiToString(buf []byte) (nai string, plmnId string, err error) {
+	// Split buf in username and realm
+	parts := strings.SplitN(string(buf), "@", 2)
+	if len(parts) != 2 {
+		return "", "", errors.New("invalid NAI format: missing @")
 	}
-	prefix := "nai"
-	naiBytes := buf[1:]
-	naiStr := hex.EncodeToString(naiBytes)
-	nai = strings.Join([]string{prefix, "1", naiStr}, "-")
-	return
+	username := parts[0]
+	realm := parts[1]
+
+	// Parse SUPI type, routing indicator and protection scheme id
+	baseMatch := reBase.FindStringSubmatch(username)
+	if baseMatch == nil || len(baseMatch) < 4 {
+		return "", "", errors.New("invalid NAI username format: missing type, rid or schid")
+	}
+	supiType := baseMatch[1]
+	rid := baseMatch[2]
+	protectionSchemeID := baseMatch[3]
+
+	// Parse Scheme Output (Null, Profile A, Profile B, HPLMN Proprietary)
+	rest := username[len(baseMatch[0]):]
+	schemeOutput := ""
+	homeNetworkPublicKeyID := ""
+	switch {
+	case strings.HasPrefix(rest, ".userid"):
+		// Null Scheme
+		if protectionSchemeID != "0" {
+			return "", "", errors.New("userid is admitted only when protection scheme is null")
+		}
+		schemeOutput = strings.TrimPrefix(rest, ".userid")
+		homeNetworkPublicKeyID = "0"
+
+	case strings.HasPrefix(rest, ".hnkey"):
+		hnMatch := reHN.FindStringSubmatch(rest)
+		if hnMatch == nil {
+			return "", "", errors.New("invalid home network public key identifier format")
+		}
+		homeNetworkPublicKeyID = hnMatch[1]
+
+		rest = rest[len(hnMatch[0]):]
+		if strings.HasPrefix(rest, ".ecckey") {
+			// Profile A or B Scheme
+			eccMatch := reECC.FindStringSubmatch(rest)
+			if eccMatch == nil {
+				return "", "", errors.New("invalid ECC format")
+			}
+
+			ecc := eccMatch[1]
+			cip := eccMatch[2]
+			mac := eccMatch[3]
+			schemeOutput = ecc + cip + mac
+
+		} else if strings.HasPrefix(rest, ".out") {
+			// HPLMN Proprietary Scheme
+			schemeOutput = strings.TrimPrefix(rest, ".out")
+
+		} else {
+			return "", "", errors.New("unknown protection scheme output")
+		}
+
+	default:
+		return "", "", errors.New("invalid NAI username for SUCI")
+	}
+
+	// Parse MCC and MNC or NSI Realm
+	homeNetworkID := ""
+	match := rePLMN.FindStringSubmatch(realm)
+	plmnId = ""
+	if match == nil || len(match) < 3 {
+		homeNetworkID = realm
+	} else {
+		mcc := match[2]
+		mnc := match[1]
+		if len(mnc) == 3 {
+			mnc = strings.TrimPrefix(mnc, "0")
+		}
+
+		homeNetworkID = mcc + "-" + mnc
+		plmnId = mcc + mnc
+	}
+
+	// Build SUCI in UTF-8 string format
+	suci := strings.Join([]string{
+		"suci", supiType, homeNetworkID, rid, protectionSchemeID, homeNetworkPublicKeyID, schemeOutput,
+	}, "-")
+
+	return suci, plmnId, nil
 }
 
 // nasType: TS 24.501 9.11.3.4

--- a/nasConvert/MobileIdentity5GS.go
+++ b/nasConvert/MobileIdentity5GS.go
@@ -49,12 +49,13 @@ func SuciToStringWithError(buf []byte) (suci string, plmnId string, err error) {
 	}
 
 	supiFormat := (buf[0] & 0xf0) >> 4
-	if supiFormat == nasMessage.SupiFormatNai {
+	switch supiFormat {
+	case nasMessage.SupiFormatNai:
 		suci, plmnId, err = naiToString(buf[1:])
 		return suci, plmnId, err
-	} else if supiFormat == nasMessage.SupiFormatGCI {
+	case nasMessage.SupiFormatGCI:
 		return "", "", errors.New("GCI not supported")
-	} else if supiFormat == nasMessage.SupiFormatGLI {
+	case nasMessage.SupiFormatGLI:
 		return "", "", errors.New("GLI not supported")
 	}
 
@@ -118,7 +119,7 @@ func SuciToStringWithError(buf []byte) (suci string, plmnId string, err error) {
 	return suci, plmnId, nil
 }
 
-/* NAI format for SUCI has the form username@realm (Ref. TS 24 501 Sec. 28.7). Where:
+/* NAI format for SUCI has the form username@realm (Ref. TS 23.003 Section 28.7.3). Where:
  * realm = [ (nai.)5gc.mnc<MNC>.mcc<MCC>.3gppnetwork.org || <NSI realm> ]
  * username = type<supi type>.rid<routing indicator>.schid<protection scheme id>
  * [ .userid<MSIN || NSI username> ||
@@ -132,10 +133,12 @@ func SuciToStringWithError(buf []byte) (suci string, plmnId string, err error) {
  * <ECC ephemeral public key><ciphertext><MAC tag> || <HPLMN defined scheme output>]"
  */
 
-var reBase = regexp.MustCompile(`^type(\d{1})\.rid(\d{1,4})\.schid(\d{1})`)
-var reHN = regexp.MustCompile(`^\.hnkey(\d{1,3})`)
-var reECC = regexp.MustCompile(`^\.ecckey([^.]+)\.cip([^.]+)\.mac([^.]+)`)
-var rePLMN = regexp.MustCompile(`^.*\.mnc(\d{2,3})\.mcc(\d{3})\.3gppnetwork\.org$`)
+var (
+	reBase = regexp.MustCompile(`^type(\d{1})\.rid(\d{1,4})\.schid(\d{1})\.`)
+	reHN   = regexp.MustCompile(`^hnkey(\d{1,3})\.`)
+	reECC  = regexp.MustCompile(`^ecckey([0-9A-Fa-f]+)\.cip([0-9A-Fa-f]+)\.mac([0-9a-fA-F]{16})$`)
+	rePLMN = regexp.MustCompile(`^.*\.mnc(\d{2,3})\.mcc(\d{3})\.3gppnetwork\.org$`)
+)
 
 func NaiToString(buf []byte) (nai string) {
 	var err error
@@ -147,7 +150,7 @@ func NaiToString(buf []byte) (nai string) {
 	return
 }
 
-func naiToString(buf []byte) (nai string, plmnId string, err error) {
+func naiToString(buf []byte) (suci string, plmnId string, err error) {
 	// Split buf in username and realm
 	parts := strings.SplitN(string(buf), "@", 2)
 	if len(parts) != 2 {
@@ -158,27 +161,31 @@ func naiToString(buf []byte) (nai string, plmnId string, err error) {
 
 	// Parse SUPI type, routing indicator and protection scheme id
 	baseMatch := reBase.FindStringSubmatch(username)
-	if baseMatch == nil || len(baseMatch) < 4 {
+	if len(baseMatch) < 4 {
 		return "", "", errors.New("invalid NAI username format: missing type, rid or schid")
 	}
 	supiType := baseMatch[1]
 	rid := baseMatch[2]
-	protectionSchemeID := baseMatch[3]
+
+	protectionSchemeID, err := strconv.Atoi(baseMatch[3])
+	if err != nil {
+		return "", "", errors.New("invalid protection scheme id: not a number")
+	}
 
 	// Parse Scheme Output (Null, Profile A, Profile B, HPLMN Proprietary)
 	rest := username[len(baseMatch[0]):]
 	schemeOutput := ""
 	homeNetworkPublicKeyID := ""
 	switch {
-	case strings.HasPrefix(rest, ".userid"):
+	case strings.HasPrefix(rest, "userid"):
 		// Null Scheme
-		if protectionSchemeID != "0" {
+		if protectionSchemeID != nasMessage.ProtectionSchemeNullScheme {
 			return "", "", errors.New("userid is admitted only when protection scheme is null")
 		}
-		schemeOutput = strings.TrimPrefix(rest, ".userid")
+		schemeOutput = strings.TrimPrefix(rest, "userid")
 		homeNetworkPublicKeyID = "0"
 
-	case strings.HasPrefix(rest, ".hnkey"):
+	case strings.HasPrefix(rest, "hnkey"):
 		hnMatch := reHN.FindStringSubmatch(rest)
 		if hnMatch == nil {
 			return "", "", errors.New("invalid home network public key identifier format")
@@ -186,7 +193,11 @@ func naiToString(buf []byte) (nai string, plmnId string, err error) {
 		homeNetworkPublicKeyID = hnMatch[1]
 
 		rest = rest[len(hnMatch[0]):]
-		if strings.HasPrefix(rest, ".ecckey") {
+		if strings.HasPrefix(rest, "ecckey") {
+			if protectionSchemeID != nasMessage.ProtectionSchemeECIESProfileA &&
+				protectionSchemeID != nasMessage.ProtectionSchemeECIESProfileB {
+				return "", "", errors.New("ecckey is admitted only for protection scheme profiles A and B")
+			}
 			// Profile A or B Scheme
 			eccMatch := reECC.FindStringSubmatch(rest)
 			if eccMatch == nil {
@@ -196,12 +207,24 @@ func naiToString(buf []byte) (nai string, plmnId string, err error) {
 			ecc := eccMatch[1]
 			cip := eccMatch[2]
 			mac := eccMatch[3]
+
+			if protectionSchemeID == nasMessage.ProtectionSchemeECIESProfileA && len(ecc) != 64 {
+				return "", "", errors.New("ecc key must be 64 characters long for profile A")
+			}
+
+			if protectionSchemeID == nasMessage.ProtectionSchemeECIESProfileB && len(ecc) != 66 {
+				return "", "", errors.New("ecc key must be 66 characters long for profile B")
+			}
+
 			schemeOutput = ecc + cip + mac
-
-		} else if strings.HasPrefix(rest, ".out") {
+		} else if strings.HasPrefix(rest, "out") {
 			// HPLMN Proprietary Scheme
-			schemeOutput = strings.TrimPrefix(rest, ".out")
-
+			if protectionSchemeID == nasMessage.ProtectionSchemeNullScheme ||
+				protectionSchemeID == nasMessage.ProtectionSchemeECIESProfileA ||
+				protectionSchemeID == nasMessage.ProtectionSchemeECIESProfileB {
+				return "", "", errors.New("out is admitted only for proprietary protection schemes")
+			}
+			schemeOutput = strings.TrimPrefix(rest, "out")
 		} else {
 			return "", "", errors.New("unknown protection scheme output")
 		}
@@ -214,7 +237,7 @@ func naiToString(buf []byte) (nai string, plmnId string, err error) {
 	homeNetworkID := ""
 	match := rePLMN.FindStringSubmatch(realm)
 	plmnId = ""
-	if match == nil || len(match) < 3 {
+	if len(match) < 3 {
 		homeNetworkID = realm
 	} else {
 		mcc := match[2]
@@ -228,8 +251,8 @@ func naiToString(buf []byte) (nai string, plmnId string, err error) {
 	}
 
 	// Build SUCI in UTF-8 string format
-	suci := strings.Join([]string{
-		"suci", supiType, homeNetworkID, rid, protectionSchemeID, homeNetworkPublicKeyID, schemeOutput,
+	suci = strings.Join([]string{
+		"suci", supiType, homeNetworkID, rid, strconv.Itoa(protectionSchemeID), homeNetworkPublicKeyID, schemeOutput,
 	}, "-")
 
 	return suci, plmnId, nil

--- a/nasConvert/MobileIdentity5GS_test.go
+++ b/nasConvert/MobileIdentity5GS_test.go
@@ -38,15 +38,6 @@ func TestSuciToStringWithError(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name: "SUSI-NAI",
-			args: args{
-				buf: []byte{0x11, 0x02, 0x58, 0x39, 0xf0, 0xff, 0x01, 0x00, 0x00, 0x00, 0x00, 0x10},
-			},
-			wantSuci:   "nai-1-025839f0ff010000000010",
-			wantPlmnId: "",
-			wantErr:    false,
-		},
-		{
 			name: "SUSI-short",
 			args: args{
 				buf: []byte{0x01, 0x02, 0xf8, 0x39, 0xf0, 0xff, 0x00, 0x00, 0x00},
@@ -70,20 +61,131 @@ func TestSuciToStringWithError(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "SUSI-NAI-short",
+			name: "TS23003-28.7.3-Examples-SUCI-NAI-IMSI",
 			args: args{
-				buf: []byte{0x11, 0x02},
+				buf: append([]byte{0x11}, []byte("type0.rid678.schid0.userid0999999999@5gc.mnc015.mcc234.3gppnetwork.org")...),
 			},
-			wantSuci:   "nai-1-02",
+			wantSuci:   "suci-0-234-15-678-0-0-0999999999",
+			wantPlmnId: "23415",
+			wantErr:    false,
+		},
+		{
+			name: "TS23003-28.7.3-Examples-SUCI-NAI-NSI",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type1.rid678.schid0.useriduser17@example.com")...),
+			},
+			wantSuci:   "suci-1-example.com-678-0-0-user17",
 			wantPlmnId: "",
 			wantErr:    false,
 		},
 		{
-			name: "SUSI-NAI-too-short",
+			name: "SUCI-NAI-too-short",
 			args: args{
 				buf: []byte{0x11},
 			},
 			wantErr: true,
+		},
+		{
+			name: "SUCI-NAI-invalid-username-format",
+			args: args{
+				buf: append([]byte{0x11}, []byte("username@example.com")...),
+			},
+			wantErr: true,
+		},
+		{
+			name: "SUCI-NAI-invalid-missing-@",
+			args: args{
+				buf: append([]byte{0x11}, []byte("username.example.com")...),
+			},
+			wantErr: true,
+		},
+		{
+			name: "SUCI-NAI-invalid-protection-scheme",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type0.rid678.schid3.username@example.com")...),
+			},
+			wantErr: true,
+		},
+		{
+			name: "TS23003-28.7.6-trusted-non-3GPP-access",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type0.rid678.schid0.userid0999999999@nai.5gc.mnc001.mcc001.3gppnetwork.org")...),
+			},
+			wantSuci:   "suci-0-001-01-678-0-0-0999999999",
+			wantPlmnId: "00101",
+			wantErr:    false,
+		},
+		{
+			name: "TS23003-28.7.7-trusted-non-3GPP-access-N5CW",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type0.rid678.schid0.userid0999999999@nai.5gc-nn.mnc001.mcc001.3gppnetwork.org")...),
+			},
+			wantSuci:   "suci-0-001-01-678-0-0-0999999999",
+			wantPlmnId: "00101",
+			wantErr:    false,
+		},
+		{
+			name: "TS23003-28.7.12-NSWO",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type0.rid678.schid0.userid0999999999@5gc-nswo.nid1234.mnc001.mcc001.3gppnetwork.org")...),
+			},
+			wantSuci:   "suci-0-001-01-678-0-0-0999999999",
+			wantPlmnId: "00101",
+			wantErr:    false,
+		},
+		{
+			name: "TS29503-AnnexC-Example1",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type0.rid012.schid0.userid0123456789@5gc.mnc045.mcc123.3gppnetwork.org")...),
+			},
+			wantSuci:   "suci-0-123-45-012-0-0-0123456789",
+			wantPlmnId: "12345",
+			wantErr:    false,
+		},
+		{
+			name: "TS29503-AnnexC-Example2",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type0.rid0002.schid1.hnkey17.ecckeye9b9916c911f448d8792e6b2f387f85d3ecab9040049427d9edbb5431b0bc711.cip023be6a057.macb45d936238aebeb7@5gc.mnc045.mcc123.3gppnetwork.org")...),
+			},
+			wantSuci:   "suci-0-123-45-0002-1-17-e9b9916c911f448d8792e6b2f387f85d3ecab9040049427d9edbb5431b0bc711023be6a057b45d936238aebeb7",
+			wantPlmnId: "12345",
+			wantErr:    false,
+		},
+		{
+			name: "TS29503-AnnexC-Example3",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type1.rid84.schid2.hnkey250.ecckeye9b9916c911f448d8792e6b2f387f85d3ecab9040049427d9edbb5431b0bc71195.cip023be6a057.macb45d936238aebeb7@example.com")...),
+			},
+			wantSuci:   "suci-1-example.com-84-2-250-e9b9916c911f448d8792e6b2f387f85d3ecab9040049427d9edbb5431b0bc71195023be6a057b45d936238aebeb7",
+			wantPlmnId: "",
+			wantErr:    false,
+		},
+		{
+			name: "TS29503-AnnexC-Example4",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type3.rid012.schid0.userid00-00-5E-00-53-00@operator.com")...),
+			},
+			wantSuci:   "suci-3-operator.com-012-0-0-00-00-5E-00-53-00",
+			wantPlmnId: "",
+			wantErr:    false,
+		},
+		{
+			name: "TS29503-AnnexC-Example5",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type1.rid3456.schid0.useridanonymous@operator.com")...),
+			},
+			wantSuci:   "suci-1-operator.com-3456-0-0-anonymous",
+			wantPlmnId: "",
+			wantErr:    false,
+		},
+		{
+			name: "TS29503-AnnexC-Example5-Alternative",
+			args: args{
+				buf: append([]byte{0x11}, []byte("type1.rid3456.schid0.userid@operator.com")...),
+			},
+			wantSuci:   "suci-1-operator.com-3456-0-0-",
+			wantPlmnId: "",
+			wantErr:    false,
 		},
 	}
 	for _, tt := range tests {

--- a/nasMessage/NAS_CommInfoIE.go
+++ b/nasMessage/NAS_CommInfoIE.go
@@ -231,6 +231,8 @@ const (
 const (
 	SupiFormatImsi uint8 = 0x00
 	SupiFormatNai  uint8 = 0x01
+	SupiFormatGCI  uint8 = 0x02
+	SupiFormatGLI  uint8 = 0x03
 )
 
 // TS 24.501 9.11.3.4


### PR DESCRIPTION
### Summary

3GPP TS 24 501 defines four different SUPI Formats to be sent as SUCI in the _NAS 5GS Mobile Identity IE_ [1]: **IMSI** (International Mobile Subscriber Identity), **NSI** (Network Specific Identifier), **GCI** (Global Cable Identifier), and **GLI** (Global Line Identifier). If the SUPI format is set to NSI, the SUCI is encoded as an **NAI** constructed as specified in Section 28.7.3 of 3GPP TS 23.003 [2]. This pull request updates the `free5gc/nas` module to include the support of SUCI in NAI format.



### Motivation

Actually, Free5GC supports only the IMSI format for the SUPI. When the SUCI is encoded in NSI format, the _naiToString()_ function only adds the prefix "nai-1-" and appends the SUCI NAI field. With this pull request, the _SuciToStringWithError()_ function is updated to detect the SUPI format. If the SUPI format is of type NSI, the _naiToString()_ function is called to parse the SUCI NAI field and construct the SUCI UTF-8 string to be sent to the UDM API (via the supiOrSuci parameter) as specified in TS 29 503 Annex C [3]. As a result, UEs can also authenticate using the SUCI in NAI format in the 5G NAS Registration Request.



### Changes

- Added _SupiFormatGCI_ and _SupiFormatGLI_ types in _NAS_CommInfoIE.go_.
- Updated _SuciToStringWithError()_ function to distinguish between SUPI formats: IMSI, NAI, GCI, and GLI.
- Updated _naiToString()_ function to parse SUCI in NAI format.
- Added some tests taken directly from the 3GPP TS [2,3] in _MobileIdentity5GS_test.go_.



### Validation
Validation is performed through: (1) the test cases provided in _MobileIdentity5GS_test.go_, and (2) Free5GC (commit 69ba98ff8eba69a8092c56abb80a01fcd483e7b3). More specifically, _registration_test.go_ has been extended with a new test case in which a UE completes the registration procedure using a SUCI in NAI format. If this is of interest, I can open a pull request in the `free5gc/free5gc` module to share the additional test.



### Notes

- The Decorated NAI used in roaming scenarios is still not supported (Ref. 3GPP TS 123 003 Section 28.7.9.1).
- With a bit of further effort it is also possible to add the support of SUPI formats: CGI, and GLI (as specified in 3GPP TS 123 003 Sections 28.15 and 28.16).


### References
1. 3GPP TS 124 501 Section 9.11.3.4 (5GS Mobile Identity IE).
2. 3GPP TS 123 003 Sections 28.7.3 (NAI format for SUCI), 28.7.6 (NAI used for 5G registration via trusted non-3GPP access), 28.7.7 (NAI used by N5CW devices via trusted non-3GPP access), 28.7.12 (NAI used for 5G NSWO).
3. 3GPP TS 129 503 Annex C (SUCI encoding).
    